### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,6 @@ variable "vm-template-name" {
 
 variable "vm-domain" {
   type        = string
-  description = "Linux virtual machine domain name for the machine. This, along with host_name, make up the FQDN of the virtual machine"  description = "Linux virtual machine domain name"
+  description = "Linux virtual machine domain name for the machine. This, along with host_name, make up the FQDN of the virtual machine"
   default     = ""
 }


### PR DESCRIPTION
remove accidental inclusion of old description / 2nd key=value on one line to prevent error:
Error: Missing newline after argument

  on variables.tf line 102, in variable "vm-domain":
 102:   description = "[...]"

An argument definition must end with a newline.